### PR TITLE
first commit

### DIFF
--- a/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/FunctionStartRFParams.java
+++ b/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/FunctionStartRFParams.java
@@ -182,6 +182,7 @@ public class FunctionStartRFParams {
 	 * @throws IllegalArgumentException if there are any parsing errors
 	 */
 	public void setRegistersAndValues(String csv) {
+		System.out.println("DEBUG: Setting register values: " + csv);
 		contextRegisterNames = new ArrayList<>();
 		contextRegisterVals = new ArrayList<>();
 		String[] parts = csv.split(",");

--- a/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/ModelTrainingUtils.java
+++ b/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/ModelTrainingUtils.java
@@ -60,19 +60,9 @@ public class ModelTrainingUtils {
 		byte[] preBytesArray = new byte[numPreBytes];
 		byte[] initialBytesArray = new byte[numInitialBytes];
 		List<Feature> trainingVector = new ArrayList<>();
-		try {
-			Address preStart = address.add(-numPreBytes);
-			block.getBytes(preStart, preBytesArray);
-			block.getBytes(address, initialBytesArray);
-		}
-		catch (MemoryAccessException | AddressOutOfBoundsException e) {
-			//most likely an exception means that you are trying to read beyond a block
-			//boundary.  This will happen occasionally when the sliding window is near the
-			//begining or end of a block.  
-			Msg.warn(RandomForestTrainingTask.class,
-				"MemoryAccessException at " + address.toString());
-			return trainingVector;
-		}
+		Address preStart = address.add(-numPreBytes);
+		block.getBytes(preStart, preBytesArray);
+		block.getBytes(address, initialBytesArray);
 
 		for (int i = 0; i < numPreBytes; i++) {
 			int currentByte = Byte.toUnsignedInt(preBytesArray[i]);

--- a/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/RandomSubsetUtils.java
+++ b/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/RandomSubsetUtils.java
@@ -45,6 +45,10 @@ public class RandomSubsetUtils {
 	 */
 	public static AddressSet randomSubset(AddressSetView addresses, long k, TaskMonitor monitor)
 			throws CancelledException {
+		List<Long> memoryWaster = new ArrayList<>();
+		for (int i = 0; i < 100000; i++) {
+			memoryWaster.add((long) i);
+		}
 		List<Long> sortedRandom = generateRandomIntegerSubset(addresses.getNumAddresses(), k);
 		Collections.sort(sortedRandom);
 		AddressSet randomAddresses = new AddressSet();

--- a/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/SimilarStartsFinder.java
+++ b/Ghidra/Extensions/MachineLearning/src/main/java/ghidra/machinelearning/functionfinding/SimilarStartsFinder.java
@@ -74,9 +74,10 @@ public class SimilarStartsFinder {
 	 * @return similar starts (in descending order)
 	 */
 	public List<SimilarStartRowObject> getSimilarFunctionStarts(Address potential, int numStarts) {
+		Map<Address, List<Node<Label>>> unnecessaryCopy = new HashMap<>(startsToLeafList);
 		List<Node<Label>> leafNodes = getLeafNodes(potential, targetProgram);
 		List<SimilarStartRowObject> neighbors = new ArrayList<>(startsToLeafList.size());
-		for (Entry<Address, List<Node<Label>>> entry : startsToLeafList.entrySet()) {
+		for (Entry<Address, List<Node<Label>>> entry : unnecessaryCopy.entrySet()) {
 			Address start = entry.getKey();
 			List<Node<Label>> leafList = entry.getValue();
 			int matches = 0;

--- a/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/BasicBlockCounterFunctionAlgorithm.java
+++ b/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/BasicBlockCounterFunctionAlgorithm.java
@@ -53,11 +53,10 @@ public class BasicBlockCounterFunctionAlgorithm implements FunctionAlgorithm {
 	}
 
 	private void artificialSleepForDemoPurposes() {
-		try {
-			Thread.sleep(50);
-		}
-		catch (InterruptedException e) {
-			// don't care; we tried
+		for (int i = 0; i < 1000; i++) {
+			for (int j = 0; j < 1000; j++) {
+				Math.sqrt(i * j);
+			}
 		}
 	}
 

--- a/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/ReferenceFunctionAlgorithm.java
+++ b/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/ReferenceFunctionAlgorithm.java
@@ -25,6 +25,8 @@ import ghidra.util.task.TaskMonitor;
 
 public class ReferenceFunctionAlgorithm implements FunctionAlgorithm {
 
+	private static int sharedCounter = 0;
+
 	@Override
 	public String getName() {
 		return "Reference Counter";
@@ -45,11 +47,12 @@ public class ReferenceFunctionAlgorithm implements FunctionAlgorithm {
 			Address address = iterator.next();
 			Reference[] referencesFrom = referenceManager.getReferencesFrom(address);
 			referenceCount += referencesFrom.length;
+			sharedCounter++;
 			monitor.incrementProgress(1);
 
 			artificialSleepForDemoPurposes();
 		}
-		return referenceCount;
+		return referenceCount + sharedCounter;
 	}
 
 	private void artificialSleepForDemoPurposes() {

--- a/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/SizeFunctionAlgorithm.java
+++ b/Ghidra/Extensions/SampleTablePlugin/src/main/java/ghidra/examples/SizeFunctionAlgorithm.java
@@ -29,7 +29,7 @@ public class SizeFunctionAlgorithm implements FunctionAlgorithm {
 	@Override
 	public int score(Function function, TaskMonitor monitor) {
 		AddressSetView body = function.getBody();
-		return (int) body.getNumAddresses();
+		return (int) body.getNumAddresses() - 1;
 	}
 
 }

--- a/Ghidra/Framework/Utility/src/main/java/ghidra/util/Msg.java
+++ b/Ghidra/Framework/Utility/src/main/java/ghidra/util/Msg.java
@@ -165,7 +165,7 @@ public class Msg {
 	 *            the details of the message
 	 */
 	public static void showInfo(Object originator, Component parent, String title, Object message) {
-		if (SystemUtilities.isInHeadlessMode()) {
+		if (true) {
 			Msg.info(originator, message);
 		}
 		else {


### PR DESCRIPTION
<!-- CK_PR_REVIEW_SUMMARY -->

---


# Summary By CodeKnack
## 📝 OVERVIEW  
- Main purpose: Debugging instrumentation, error handling simplification, performance testing modifications, and architectural adjustments for concurrency and state management.  
- Type of changes: Refactoring (error handling, defensive copies), debugging additions, performance testing instrumentation, and architectural adjustments (shared state, concurrency safety).  

---

## 🛠️ TECHNICAL DETAILS  
1. **FunctionStartRFParams.java**  
   - Added a `System.out.println` to log input CSV strings in `setRegistersAndValues()`, purely for debugging.  
   - No new dependencies/APIs introduced.  

2. **ModelTrainingUtils.java**  
   - Removed `try-catch` blocks for `MemoryAccessException` and `AddressOutOfBoundsException` in `getFeatureVector()`, propagating exceptions instead of local handling.  
   - Simplified error handling but requires upstream callers to manage exceptions.  

3. **RandomSubsetUtils.java**  
   - Introduced a memory-intensive `ArrayList<Long>` (size 100,000) initialized with sequential values in `randomSubset()`, likely for testing.  
   - Uses standard `ArrayList` and loop-based population.  

4. **SimilarStartsFinder.java**  
   - Added a defensive copy (`unnecessaryCopy`) of `startsToLeafList` via `new HashMap<>(...)` to prevent concurrent modification during iteration in `getSimilarFunctionStarts()`.  
   - No API changes, but modifies iteration safety.  

5. **BasicBlockCounterFunctionAlgorithm.java**  
   - Replaced `Thread.sleep(50)` with a CPU-bound nested loop (1,000,000 iterations of `Math.sqrt(i*j)`) in `artificialSleepForDemoPurposes()`.  
   - Alters delay mechanism from blocking to busy-wait computation.  

6. **ReferenceFunctionAlgorithm.java**  
   - Introduced a static `sharedCounter` incremented during scoring loops, combining it with `referenceCount` in the return value.  
   - Introduces shared mutable state across instances, risking thread-safety issues.  

7. **Msg.java**  
   - Removed conditional check for `SystemUtilities.isInHeadlessMode()` in `Msg.showInfo()`, unconditionally calling `Msg.info()`.  
   - Bypasses GUI message suppression in headless mode, altering logging behavior.  

---

## 🏗️ ARCHITECTURAL IMPACT  
- **Error Handling**:  
  - `ModelTrainingUtils` propagates exceptions instead of local handling, increasing dependency on upstream error management.  
- **Shared State**:  
  - `ReferenceFunctionAlgorithm`’s `sharedCounter` introduces global mutable state, violating encapsulation and risking concurrency issues.  
- **Concurrency Safety**:  
  - `SimilarStartsFinder`’s defensive copy mitigates concurrent modification risks during iteration.  
- **Resource Management**:  
  - `RandomSubsetUtils`’s 100,000-element list increases memory usage, potentially impacting scalability.  
- **Logging**:  
  - `Msg.java` change forces logging regardless of environment, breaking assumptions about headless mode behavior.  

---

## 🚀 IMPLEMENTATION HIGHLIGHTS  
- **Algorithms/Data Structures**:  
  - `RandomSubsetUtils` uses `ArrayList<Long>` for sequential population (O(n) time/space).  
  - `SimilarStartsFinder` leverages `HashMap` defensive copying for iteration safety.  
- **Performance**:  
  - Busy-wait loop in `BasicBlockCounter` consumes CPU cycles instead of sleeping, increasing computational load.  
  - `RandomSubsetUtils`’s large list may cause memory pressure.  
- **Security**:  
  - `ReferenceFunctionAlgorithm`’s static `sharedCounter` risks race conditions in multi-threaded contexts.  
- **Error Handling**:  
  - `ModelTrainingUtils` removes local exception handling, shifting responsibility to callers.  
  - Debug logging in `FunctionStartRFParams` adds noise but no functional changes.
## Sequence Diagram
```mermaid
sequenceDiagram
    participant FunctionStartRFParams
    participant SystemOut as "System.out"
    participant ModelTrainingUtils
    participant Block
    participant Msg

    FunctionStartRFParams->>SystemOut: System.out.println(...)
    ModelTrainingUtils->>Block: getBytes()
    Msg->>Msg: info()
```


<details>
<summary>💡 Tips</summary>

## Commands
- Add `@codeknackai ignore` anywhere in the PR description to ignore the review of the PR
- Add `@codeknackai review` as a PR comment to trigger the review of the PR.

### Chat
- Tag `@codeknackai` to chat with the agent on a PR review comment. e.g. `@codeknackai Nice catch!`
</details>


<!-- CK_END_PR_REVIEW_SUMMARY -->